### PR TITLE
improve cli and argument parsing

### DIFF
--- a/src/acmsg/__main__.py
+++ b/src/acmsg/__main__.py
@@ -77,7 +77,7 @@ def print_message(message):
 def prompt_for_action(message):
     prompt = (
         Fore.LIGHTBLACK_EX
-        + "Commit with this message? (y/n/e[dit]): "
+        + "Commit with this message? ([y]es/[n]o/[e]dit): "
         + Style.RESET_ALL
     )
 
@@ -98,7 +98,7 @@ def prompt_for_action(message):
                     print(f"{Fore.RED}Invalid option: {opt}{Style.RESET_ALL}")
                 else:
                     print(
-                        f"{Fore.MAGENTA}Invalid option: {opt}{Style.RESET_ALL}"
+                        f"{Fore.MAGENTA}Please specify one of; [y]es, [n]o, [e]dit.{Style.RESET_ALL}"
                     )
 
 
@@ -154,48 +154,70 @@ def handle_config(args):
     cfg = Config()
 
     if hasattr(args, "token") and args.token:
-        cfg.set_option(option="api_token", value=args.token)
+        cfg.set_parameter(parameter="api_token", value=args.token)
         print("API token configuration saved.")
         return True
 
     if hasattr(args, "model") and args.model:
-        cfg.set_option(option="model", value=args.model)
+        cfg.set_parameter(parameter="model", value=args.model)
         print("Model configuration saved.")
         return True
 
     if hasattr(args, "_") and args._:
-        print("Error: invalid configuration option")
+        print("Error: invalid configuration parameter")
         return False
 
 
 def main():
-    parser = argparse.ArgumentParser(prog="acmsg")
+    parser = argparse.ArgumentParser(
+        prog="acmsg",
+        description="Automated commit message generator",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
     subparsers = parser.add_subparsers(dest="command", help="Commands")
 
     commit_parser = subparsers.add_parser(
-        "commit", help="generate commit message"
+        "commit",
+        help="Generate a commit message using AI",
+        description="Analyze your staged changes and generate a suitable commit message",
     )
     commit_parser.add_argument(
-        "--model", type=str, help="model to use for generation"
+        "--model",
+        type=str,
+        help="Specify the AI model used for generation (overrides config)",
     )
 
     config_parser = subparsers.add_parser(
-        "config", help="configuration commands"
+        "config",
+        help="Manage configuration settings",
+        description="Modify or display configuration parameters",
     )
-    config_subparsers = config_parser.add_subparsers(dest="config_command")
+
+    config_subparsers = config_parser.add_subparsers(dest="config_subcommand")
 
     config_set = config_subparsers.add_parser(
-        "set", help="set configuration option value"
+        "set",
+        help="Set a configuration parameter",
+        description="Set the value of a parameter in your config file.",
     )
     config_set.add_argument(
-        "option", choices=["api_token", "model"], help="configuration option"
+        "parameter",
+        choices=["api_token", "model"],
+        help="Parameter name",
     )
-    config_set.add_argument("value", type=str, help="option value")
+    config_set.add_argument("value", type=str, help="Value")
 
     config_get = config_subparsers.add_parser(
-        "get", help="get value of configuration option"
+        "get",
+        help="Display a configuration parameter",
+        description="Show the current value of a configuration parameter.",
     )
-    config_get.add_argument("option", choices=["api_token", "model"])
+    config_get.add_argument(
+        "parameter",
+        choices=["api_token", "model"],
+        help="Parameter name",
+    )
 
     subparsers.add_parser("help", help="Show help")
 
@@ -208,19 +230,19 @@ def main():
     if args.command == "commit":
         handle_commit(args)
     elif args.command == "config":
-        if args.config_command == "set":
-            if args.option == "api_token":
+        if args.config_subcommand == "set":
+            if args.parameter == "api_token":
                 args.token = args.value
-            elif args.option == "model":
+            elif args.parameter == "model":
                 args.model = args.value
             handle_config(args)
-        elif args.config_command == "get":
+        elif args.config_subcommand == "get":
             cfg = Config()
-            if args.option == "api_token":
-                option_value = cfg.get_option("api_token")
-            elif args.option == "model":
-                option_value = cfg.get_option("model")
-            print(option_value)
+            if args.parameter == "api_token":
+                parameter_value = cfg.get_parameter("api_token")
+            elif args.parameter == "model":
+                parameter_value = cfg.get_parameter("model")
+            print(parameter_value)
 
 
 if __name__ == "__main__":

--- a/src/acmsg/__main__.py
+++ b/src/acmsg/__main__.py
@@ -75,7 +75,11 @@ def print_message(message):
 
 
 def prompt_for_action(message):
-    prompt = Fore.LIGHTBLACK_EX + "Commit with this message? (y/n/e[dit]): " + Style.RESET_ALL
+    prompt = (
+        Fore.LIGHTBLACK_EX
+        + "Commit with this message? (y/n/e[dit]): "
+        + Style.RESET_ALL
+    )
 
     while True:
         opt = input(prompt).lower().strip()
@@ -93,7 +97,9 @@ def prompt_for_action(message):
                 if opt != "":
                     print(f"{Fore.RED}Invalid option: {opt}{Style.RESET_ALL}")
                 else:
-                    print(f"{Fore.MAGENTA}Invalid option: {opt}{Style.RESET_ALL}")
+                    print(
+                        f"{Fore.MAGENTA}Invalid option: {opt}{Style.RESET_ALL}"
+                    )
 
 
 def handle_commit(args):
@@ -166,17 +172,29 @@ def main():
     parser = argparse.ArgumentParser(prog="acmsg")
     subparsers = parser.add_subparsers(dest="command", help="Commands")
 
-    commit_parser = subparsers.add_parser("commit", help="generate commit message")
-    commit_parser.add_argument("--model", type=str, help="model to use for generation")
+    commit_parser = subparsers.add_parser(
+        "commit", help="generate commit message"
+    )
+    commit_parser.add_argument(
+        "--model", type=str, help="model to use for generation"
+    )
 
-    config_parser = subparsers.add_parser("config", help="configuration commands")
+    config_parser = subparsers.add_parser(
+        "config", help="configuration commands"
+    )
     config_subparsers = config_parser.add_subparsers(dest="config_command")
 
-    config_set = config_subparsers.add_parser("set", help="set configuration option value")
-    config_set.add_argument("option", choices=["api_token", "model"], help="configuration option")
+    config_set = config_subparsers.add_parser(
+        "set", help="set configuration option value"
+    )
+    config_set.add_argument(
+        "option", choices=["api_token", "model"], help="configuration option"
+    )
     config_set.add_argument("value", type=str, help="option value")
 
-    config_get = config_subparsers.add_parser("get", help="get value of configuration option")
+    config_get = config_subparsers.add_parser(
+        "get", help="get value of configuration option"
+    )
     config_get.add_argument("option", choices=["api_token", "model"])
 
     subparsers.add_parser("help", help="Show help")

--- a/src/acmsg/config.py
+++ b/src/acmsg/config.py
@@ -4,18 +4,18 @@ import yaml
 
 class Config:
     def __init__(self):
-        self.config_dir = self.create_dir_if_not_exists()
-        self.config_file = self.create_file_if_not_exists()
+        self.config_dir = self.create_or_return_config_dir()
+        self.config_file = self.create_or_return_config_yaml()
         self.model = self.get_parameter("model")
         self.api_token = self.get_parameter("api_token")
 
-    def create_dir_if_not_exists(self):
-        home = os.getenv("HOME") or os.path.expanduser("~")
-        config_dir = f"{home}/.config/acmsg"
+    def create_or_return_config_dir(self):
+        home_dir = os.getenv("HOME") or os.path.expanduser("~")
+        config_dir = f"{home_dir}/.config/acmsg"
         os.makedirs(config_dir, exist_ok=True)
         return config_dir
 
-    def create_file_if_not_exists(self):
+    def create_or_return_config_yaml(self):
         config_file = f"{self.config_dir}/config.yaml"
         data = {"api_token": "", "model": "thudm/glm-4-32b:free"}
 
@@ -26,19 +26,19 @@ class Config:
 
         return config_file
 
-    def set_parameter(self, option, value):
+    def set_parameter(self, parameter, value):
         config_file = self.config_file
         with open(config_file, "r") as f:
             data = yaml.safe_load(f)
 
-        data[option] = value
+        data[parameter] = value
 
         with open(config_file, "w") as f:
             yaml.dump(data, f, default_flow_style=False)
 
-    def get_parameter(self, option):
+    def get_parameter(self, parameter):
         config_file = self.config_file
         with open(config_file, "r") as f:
             data = yaml.safe_load(f)
 
-        return data.get(option)
+        return data.get(parameter)

--- a/src/acmsg/config.py
+++ b/src/acmsg/config.py
@@ -6,8 +6,8 @@ class Config:
     def __init__(self):
         self.config_dir = self.create_dir_if_not_exists()
         self.config_file = self.create_file_if_not_exists()
-        self.model = self.get_option("model")
-        self.api_token = self.get_option("api_token")
+        self.model = self.get_parameter("model")
+        self.api_token = self.get_parameter("api_token")
 
     def create_dir_if_not_exists(self):
         home = os.getenv("HOME") or os.path.expanduser("~")
@@ -26,7 +26,7 @@ class Config:
 
         return config_file
 
-    def set_option(self, option, value):
+    def set_parameter(self, option, value):
         config_file = self.config_file
         with open(config_file, "r") as f:
             data = yaml.safe_load(f)
@@ -36,7 +36,7 @@ class Config:
         with open(config_file, "w") as f:
             yaml.dump(data, f, default_flow_style=False)
 
-    def get_option(self, option):
+    def get_parameter(self, option):
         config_file = self.config_file
         with open(config_file, "r") as f:
             data = yaml.safe_load(f)

--- a/src/acmsg/open_router.py
+++ b/src/acmsg/open_router.py
@@ -10,7 +10,9 @@ colorama.init()
 
 
 def gen_completion(api_token, git_status, git_diff, model):
-    template_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "prompts")
+    template_dir = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "prompts"
+    )
     env = Environment(loader=FileSystemLoader(template_dir))
     system_prompt_template = env.get_template("system.md")
     user_prompt_template = env.get_template("user.md")
@@ -21,7 +23,10 @@ def gen_completion(api_token, git_status, git_diff, model):
     payload = {
         "model": model,
         "messages": [
-            {"role": "system", "content": "Parse the following messages as markdown."},
+            {
+                "role": "system",
+                "content": "Parse the following messages as markdown.",
+            },
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt},
         ],

--- a/src/acmsg/prompts/system.md
+++ b/src/acmsg/prompts/system.md
@@ -38,7 +38,6 @@ Here are the rules you MUST follow when generating commit messages:
 18. Description MUST NOT end with period
 19. Body MUST be formatted as a paragraph (or paragraphs), not a bulleted, numbered, or hyphenated list
 20. Minor changes SHOULD use the type fix instead of feat
-21. If a commit affects multiple sections of the codebase, a scope MAY include multiple nouns separated by commas, each representing an affected section of the codebase.
 
 ## COMMIT MESSAGE FORMAT
 

--- a/src/acmsg/prompts/system.md
+++ b/src/acmsg/prompts/system.md
@@ -1,13 +1,21 @@
 # IDENTITY AND PURPOSE
-You are an expert git assistant specializing in writing git commit messages. Your sole passion is analyzing git diffs to find the most significant changes to code within a codebase.
+
+You are an expert at writing Git commits. Your sole passion is analyzing git diffs to find the most significant changes to code within a codebase.
+
 You are driven almost to the point of obsession over creating perfect commit messages and strive to create the most concise and informative message possible.
 
+If you can accurately express the change in just the subject line, don't include anything in the message body. Only use the body when it is providing *useful* information.
+
 ## COMMUNICATION
-- When responding to user requests, provide only the commit message content. Do not make remarks.
+
+- When responding to user requests, provide only the commit message content. Do not make remarks or include meta-commentary.
 - Do not include backticks (e.g. ` ``` ` or ` ` `) in your response.
+- Do not repeat information from the subject line in the message body.
 
 ## RULES
-**The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.**
+
+**The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'MAY', and 'OPTIONAL' in this document are to be interpreted as described in RFC 2119.**
+
 Here are the rules you MUST follow when generating commit messages:
 
 1. Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed by the OPTIONAL scope, OPTIONAL `!`, and REQUIRED terminal colon and space.
@@ -27,13 +35,15 @@ Here are the rules you MUST follow when generating commit messages:
 15. The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
 16. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
 17. Description SHOULD be 50-70 characters
-19. Description MUST NOT end with period
-20. Body MUST be formatted as a paragraph (or paragraphs), not a bulleted, numbered, or hyphenated list
-21. Minor changes SHOULD use the type fix instead of feat
-23. If a commit affects multiple sections of the codebase, a scope MAY include multiple nouns separated by commas, each representing an affected section of the codebase.
+18. Description MUST NOT end with period
+19. Body MUST be formatted as a paragraph (or paragraphs), not a bulleted, numbered, or hyphenated list
+20. Minor changes SHOULD use the type fix instead of feat
+21. If a commit affects multiple sections of the codebase, a scope MAY include multiple nouns separated by commas, each representing an affected section of the codebase.
 
 ## COMMIT MESSAGE FORMAT
+
 Here is an example of the format you MUST follow when creating a commit message:
+
 ```
 <type>[optional scope]: <description>
 
@@ -43,22 +53,23 @@ Here is an example of the format you MUST follow when creating a commit message:
 ```
 
 ## COMMIT MESSAGE EXAMPLES
+
 Here are some full-formed examples of commit messages:
 
 ```
-  feat(api): send an email to the customer when a product is shipped
+feat(api): send an email to the customer when a product is shipped
 ```
 
 ```
-  chore(lockfile): update `nixpkgs` flake input
+chore(lockfile): update `nixpkgs` flake input
 ```
 
 ```
-  fix: prevent racing of requests
+fix: prevent racing of requests
 
-  Introduce a request id and a reference to latest request. Dismiss
-  incoming responses other than from latest request.
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
 
-  Remove timeouts which were used to mitigate the racing issue but are
-  obsolete now.
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
 ```

--- a/src/acmsg/prompts/user.md
+++ b/src/acmsg/prompts/user.md
@@ -1,16 +1,21 @@
 ## USER-SPECIFIED TASK
+
 I am about to provide you with a git diff and file statuses of the changed files in my codebase.
+
 Generate a commit message describing the changes made in the codebase based on the provided data.
+
 Bias towards a shorter message body, e.g. ~200 characters, but prioritize clarity over brevity. Write with an imperative mood.
+
 If a longer message body is required to sufficiently describe a change, then do so, but do not over explain.
-If you need a better understanding of a change, then reread the section of the git diff that corresponds
-to the change, and analyze the purpose of the changed code and its impact on the overall functionality of the codebase.
+
+Think about which changes are most significant to the functionality of the code.
 
 ## USER INPUT
-Here are the statuses of each changed file in the codebase:
-{{ status }}
----
 
-Here is the git diff of every changed file in the codebase:
+Here are the statuses of each changed file in the codebase:
+
+{{ status }}
+
+Here is the diff of every changed file in the codebase:
+
 {{ diff }}
----


### PR DESCRIPTION
This pull request introduces multiple improvements focusing on enhancing user experience, code maintainability, and commit message generation. The most significant changes include updates to the CLI interface, refactoring of configuration handling, and improvements to the commit message generation prompts.

### CLI Enhancements:
* The CLI now provides a `--version` flag to display the program version. Subcommands for `commit` and `config` have been updated with improved descriptions and help messages for better usability.
* The `config` subcommand now uses `set` and `get` subcommands for managing configuration parameters, replacing the previous structure.

### Configuration Refactoring:
* The `Config` class has been refactored to use `create_or_return_config_dir` and `create_or_return_config_yaml` methods, improving clarity and consistency in handling configuration files. Methods like `set_option` and `get_option` have been renamed to `set_parameter` and `get_parameter` for better alignment with their purpose. [[1]](diffhunk://#diff-77098f520d3e49b60b8fe21bc2be99df00086df512a78a53633e044b339e366fL7-R18) [[2]](diffhunk://#diff-77098f520d3e49b60b8fe21bc2be99df00086df512a78a53633e044b339e366fL29-R44)

### Commit Message Generation:
* The `system.md` prompt has been updated to emphasize concise and clear commit messages, discourage unnecessary repetition, and clarify formatting rules for commit messages. [[1]](diffhunk://#diff-bd019d1add2e679e066bf88f8bb1f4e30763b415655dcc2cd4550ea82cef433aL2-R18) [[2]](diffhunk://#diff-bd019d1add2e679e066bf88f8bb1f4e30763b415655dcc2cd4550ea82cef433aL30-R45)
* The `user.md` prompt now encourages prioritizing significant changes and using an imperative mood in commit messages, while simplifying the language for better clarity.

### Minor Improvements:
* Improved error messages and prompts in `handle_commit` and `prompt_for_action` functions for better user feedback. [[1]](diffhunk://#diff-0abba86da0ca48145cb4b1be8fa91a60a9109eff8e5979a0751defc40ca23c44L96-R103) [[2]](diffhunk://#diff-0abba86da0ca48145cb4b1be8fa91a60a9109eff8e5979a0751defc40ca23c44L139-R146)
* Minor formatting adjustments in `open_router.py` for better readability. [[1]](diffhunk://#diff-08d0f4cc9f262fca00b6aec2f138dc522081c946cbc4e8b1d73335db2314430eL13-R15) [[2]](diffhunk://#diff-08d0f4cc9f262fca00b6aec2f138dc522081c946cbc4e8b1d73335db2314430eL24-R29)